### PR TITLE
Correct the file path of test module.

### DIFF
--- a/octopus/tests/btc_run_tests.sh
+++ b/octopus/tests/btc_run_tests.sh
@@ -1,2 +1,2 @@
 echo '[*] BTC Disassembler [*]'
-python3 -m unittest octopus/tests/BTC/test_disassembler.py
+python3 -m unittest BTC/test_disassembler.py

--- a/octopus/tests/eos_run_tests.sh
+++ b/octopus/tests/eos_run_tests.sh
@@ -1,4 +1,4 @@
 echo '[*] EOS Disassembler [*]'
-python3 -m unittest octopus/tests/EOS/test_disassembler.py
+python3 -m unittest EOS/test_disassembler.py
 echo '[*] EOS CallGraph analysis [*]'
-python3 -m unittest octopus/tests/EOS/test_callgraph.py
+python3 -m unittest EOS/test_callgraph.py

--- a/octopus/tests/eth_run_tests.sh
+++ b/octopus/tests/eth_run_tests.sh
@@ -1,6 +1,6 @@
 # echo '[*] ETH Explorer [*]'
 # python3 -m unittest octopus/tests/ETH/test_explorer.py
 echo '[*] ETH Disassembler [*]'
-python3 -m unittest octopus/tests/ETH/test_disassembler.py
+python3 -m unittest ETH/test_disassembler.py
 echo '[*] ETH ControlFlowGraph analysis [*]'
-python3 -m unittest octopus/tests/ETH/test_cfg.py
+python3 -m unittest ETH/test_cfg.py

--- a/octopus/tests/neo_run_tests.sh
+++ b/octopus/tests/neo_run_tests.sh
@@ -1,4 +1,4 @@
 echo '[*] NEO Disassembler [*]'
-python3 -m unittest octopus/tests/NEO/test_disassembler.py
+python3 -m unittest NEO/test_disassembler.py
 echo '[*] NEO ControlFlowGraph analysis [*]'
-python3 -m unittest octopus/tests/NEO/test_cfg.py
+python3 -m unittest NEO/test_cfg.py

--- a/octopus/tests/wasm_run_tests.sh
+++ b/octopus/tests/wasm_run_tests.sh
@@ -1,4 +1,4 @@
 echo '[*] WebAssembly Disassembler [*]'
-python3 -m unittest octopus/tests/wasm/test_disassembler.py
+python3 -m unittest wasm/test_disassembler.py
 echo '[*] WebAssembly ControlFlowGraph & CallGraph analysis [*]'
-python3 -m unittest octopus/tests/wasm/test_cfg.py
+python3 -m unittest wasm/test_cfg.py


### PR DESCRIPTION
For the test of the specific platform, the file path in the shell script should be relative. Otherwise, error "ModuleNotFoundError" occurs.