### PR TITLE
instructions must have same offset to be equal

### DIFF
--- a/octopus/arch/wasm/instruction.py
+++ b/octopus/arch/wasm/instruction.py
@@ -32,6 +32,7 @@ class WasmInstruction(Instruction):
         """ Instructions are equal if all features match  """
         return self.opcode == other.opcode and\
             self.name == other.name and\
+            self.offset == other.offset and\
             self.insn_byte == other.insn_byte and\
             self.operand_size == other.operand_size and\
             self.pops == other.pops and\


### PR DESCRIPTION
When generating the SSA graph of a wasm module, there is a bug which causes the emulator to go into an infinite recursive loop until it runs out of memory. The bug happens around this line: https://github.com/quoscient/octopus/blob/851292c43daa283860b2837ec51e3f4029571669/octopus/arch/wasm/emulator.py#L291

The `target` instruction is only compared by instruction opcode, operand size, and etc. Missing from the comparison is the instruction offset, so it will match the first instruction in `current_f_instructions` that is the same opcode, not the actual same instruction at the same offset.

I ran into this bug when generating the SSA graph of this [wasm code](https://github.com/ewasm/ewasm-precompiles/blob/b364a4f900ff00e25c8f2191d1d32e07aef8f1be/target/wasm32-unknown-unknown/release/keccak256_c_1.wat). Patching `arch/wasm/instruction.py` to compare the offset fixes it.

