### PR TITLE
fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ In a terminal, run the following commands:
 
 ```
 docker pull smartbugs/octopus
-docker run -it octopus
+docker run -it smartbugs/octopus
 cd octopus
 python3 octopus_eth_evm.py -s -f examples/ETH/evm_bytecode/61EDCDf5bb737ADffE5043706e7C5bb1f1a56eEA.bytecode
 ```


### PR DESCRIPTION
When i try to install octopus docker, docker run -it octopus can't run but docker run -it smartbugs/octopus can run. so i fix this document typo